### PR TITLE
Supporting Intellij IDEA 2020.1 EAP

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-ideaVersion=2019.3
+ideaVersion=201-EAP-SNAPSHOT
 customSinceBuild=172.3317.76
-customUntilBuild=193.*
+customUntilBuild=201.*
 buildNumber=SNAPSHOT
 version=0.3.19

--- a/src/com/thoughtworks/gauge/annotator/CreateStepImplFix.java
+++ b/src/com/thoughtworks/gauge/annotator/CreateStepImplFix.java
@@ -112,7 +112,7 @@ public class CreateStepImplFix extends BaseIntentionAction {
 
                     @Override
                     public Icon getIconFor(PsiFile aValue) {
-                        return aValue == null ? AllIcons.Actions.CreateFromUsage : aValue.getIcon(0);
+                        return aValue == null ? AllIcons.Actions.IntentionBulb : aValue.getIcon(0);
                     }
 
                     @NotNull

--- a/src/com/thoughtworks/gauge/findUsages/StepFindUsagesHandler.java
+++ b/src/com/thoughtworks/gauge/findUsages/StepFindUsagesHandler.java
@@ -36,12 +36,12 @@ public class StepFindUsagesHandler extends FindUsagesHandler {
     }
 
     @Override
-    public boolean processElementUsages(final PsiElement psiElement, final Processor<UsageInfo> processor, final FindUsagesOptions findUsagesOptions) {
+    public boolean processElementUsages(final PsiElement psiElement, final Processor<? super UsageInfo> processor, final FindUsagesOptions findUsagesOptions) {
         ApplicationManager.getApplication().invokeLater(() -> runFindUsageReadAction(psiElement, processor, findUsagesOptions));
         return true;
     }
 
-    private void runFindUsageReadAction(final PsiElement psiElement, final Processor<UsageInfo> processor, final FindUsagesOptions findUsagesOptions) {
+    private void runFindUsageReadAction(final PsiElement psiElement, final Processor<? super UsageInfo> processor, final FindUsagesOptions findUsagesOptions) {
         ApplicationManager.getApplication().runReadAction(() -> {
             if (psiElement instanceof PsiMethod) {
                 PsiMethod[] psiMethods = SuperMethodWarningUtil.checkSuperMethods((PsiMethod) psiElement, CustomFUH.getActionString());
@@ -53,7 +53,7 @@ public class StepFindUsagesHandler extends FindUsagesHandler {
         });
     }
 
-    public boolean processUsages(final PsiElement psiElement, final Processor<UsageInfo> processor, final FindUsagesOptions findUsagesOptions) {
+    public boolean processUsages(final PsiElement psiElement, final Processor<? super UsageInfo> processor, final FindUsagesOptions findUsagesOptions) {
         return super.processElementUsages(psiElement, processor, findUsagesOptions);
     }
 


### PR DESCRIPTION
Fixes #423 

Current state is that it compiles successfully and can be installed locally. Syntax highlighting works properly, and things appear at first glance to work, although more investigation is needed. My only concern is that during the Gradle build, the following occurs:

```
> Task :buildSearchableOptions
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.intellij.ide.IdeEventQueue to constructor sun.awt.PostEventQueue(java.awt.EventQueue)
WARNING: Please consider reporting this to the maintainers of com.intellij.ide.IdeEventQueue
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
2020-02-07 14:37:44,704 [   2690]  ERROR - nsions.impl.ExtensionPointImpl - Cannot create class com.intellij.uiDesigner.binding.FormClassIndex [Plugin: com.intellij.uiDesigner] 
com.intellij.diagnostic.PluginException: Cannot create class com.intellij.uiDesigner.binding.FormClassIndex [Plugin: com.intellij.uiDesigner]
	at com.intellij.serviceContainer.PlatformComponentManagerImpl.instantiateClass(PlatformComponentManagerImpl.kt:561)
	at com.intellij.openapi.extensions.impl.ExtensionComponentAdapter.instantiateClass(ExtensionComponentAdapter.java:54)
	at com.intellij.openapi.extensions.impl.XmlExtensionAdapter$SimpleConstructorInjectionAdapter.instantiateClass(XmlExtensionAdapter.java:132)
	at com.intellij.openapi.extensions.impl.ExtensionComponentAdapter.createInstance(ExtensionComponentAdapter.java:45)
	at com.intellij.openapi.extensions.impl.XmlExtensionAdapter.createInstance(XmlExtensionAdapter.java:68)
	at com.intellij.openapi.extensions.impl.ExtensionPointImpl.processAdapter(ExtensionPointImpl.java:431)
	at com.intellij.openapi.extensions.impl.ExtensionPointImpl.processAdapter(ExtensionPointImpl.java:418)
	at com.intellij.openapi.extensions.impl.ExtensionPointImpl.access$100(ExtensionPointImpl.java:36)
	at com.intellij.openapi.extensions.impl.ExtensionPointImpl$1.next(ExtensionPointImpl.java:326)
	at com.intellij.util.indexing.FileBasedIndexDataInitialization.initAssociatedDataForExtensions(FileBasedIndexDataInitialization.java:55)
	at com.intellij.util.indexing.FileBasedIndexDataInitialization.prepare(FileBasedIndexDataInitialization.java:91)
	at com.intellij.util.indexing.IndexInfrastructure$DataInitialization.call(IndexInfrastructure.java:120)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at com.intellij.util.concurrency.BoundedTaskExecutor.doRun(BoundedTaskExecutor.java:225)
	at com.intellij.util.concurrency.BoundedTaskExecutor.access$200(BoundedTaskExecutor.java:32)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.execute(BoundedTaskExecutor.java:204)
	at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:210)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.run(BoundedTaskExecutor.java:193)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.AssertionError: ID with name 'FormClassIndex' requested for plugin com.intellij.uiDesigner but registered for com.thoughtworks.gauge
	at com.intellij.util.indexing.ID.findByName(ID.java:169)
	at com.intellij.util.indexing.ID.create(ID.java:142)
	at com.intellij.uiDesigner.binding.FormClassIndex.<clinit>(FormClassIndex.java:41)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at com.intellij.serviceContainer.PlatformComponentManagerImpl.instantiateClass(PlatformComponentManagerImpl.kt:519)
	... 20 more
Caused by: java.lang.Throwable
	at com.intellij.util.indexing.ID.<init>(ID.java:100)
	at com.intellij.util.indexing.ID.create(ID.java:143)
	at com.thoughtworks.gauge.stub.FileStub.<clinit>(FileStub.java:31)
	... 25 more
2020-02-07 14:37:44,709 [   2695]  ERROR - nsions.impl.ExtensionPointImpl - IntelliJ IDEA 2020.1 EAP  Build #IC-201.4865.12 
2020-02-07 14:37:44,710 [   2696]  ERROR - nsions.impl.ExtensionPointImpl - JDK: 11.0.6; VM: OpenJDK 64-Bit Server VM; Vendor: JetBrains s.r.o 
2020-02-07 14:37:44,713 [   2699]  ERROR - nsions.impl.ExtensionPointImpl - OS: Windows 10 
Starting searchable options index builder
2020-02-07 14:37:45,931 [   3917]   WARN - ConfigurableExtensionPointUtil - ignore deprecated groupId: language for id: preferences.language.Kotlin.scripting 
2020-02-07 14:37:48,776 [   6762]   WARN - r.PlatformComponentManagerImpl - Do not use constructor injection (requestorClass=com.android.tools.idea.sdk.AndroidSdks) 
Searchable options index builder completed
```
Despite this error, the build completes successfully.